### PR TITLE
Fix save as Lua button

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -467,7 +467,7 @@ function createActionButtons()
     local lb = lf.Create("button")
         :SetText("Load Lua")
         :SetWidth(67)
-    sb.OnClick = loadHandler("lua", function(f) sound:load(f) end)
+    lb.OnClick = loadHandler("lua", function(f) sound:load(f) end)
     f:AddItem(lb)
 
     local bsb = lf.Create("button")


### PR DESCRIPTION
When clicking "Save Lua", the load dialog popped up instead, while when clicking "Load Lua", nothing happened.
