### PR TITLE
Updates for LÖVE 11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "loveframes"]
 	path = demo/loveframes
-	url = https://github.com/NikolaiResokav/LoveFrames
+	url = https://github.com/linux-man/LoveFrames.git

--- a/demo/conf.lua
+++ b/demo/conf.lua
@@ -1,5 +1,5 @@
 function love.conf(t)
-    t.version = love._version:match("0%.9%.%d+") or "0.9.x"
+    t.version = 11.3
     t.window.width = 640
     t.window.height = 600
     t.window.title = "sfxr.lua Demo"

--- a/demo/main.lua
+++ b/demo/main.lua
@@ -504,14 +504,14 @@ function createOther()
 
     local draw = function(o)
         if source then
-            love.graphics.setColor(255, 255, 255)
+            love.graphics.setColor(1, 1, 1)
             love.graphics.draw(wavecanvas, 495, 25)
 
             -- Draw a fancy position cursor
             local pos = source:tell("samples")
             local max = sounddata:getSampleCount()
             local x = 495 + (pos / max) * 125
-            love.graphics.setColor(255, 153, 0)
+            love.graphics.setColor(1, 0.6, 0)
             love.graphics.line(x, 25, x, 165)
         end
 
@@ -613,7 +613,7 @@ function updateWaveCanvas(waveview)
     local t = love.timer.getTime()
     wavecanvas:clear()
     love.graphics.setCanvas(wavecanvas)
-    love.graphics.setColor(255, 255, 255)
+    love.graphics.setColor(1, 1, 1)
     love.graphics.setLineStyle("rough")
 
     -- Iterate through the passed table and draw all lines to the canvas
@@ -628,7 +628,7 @@ function updateWaveCanvas(waveview)
     end
 
     -- Draw the zero line
-    love.graphics.setColor(255, 80, 51, 200)
+    love.graphics.setColor(1, 0.314, 0.2, 0.784)
     love.graphics.line(0, 70, 125, 70)
 
     love.graphics.setCanvas()

--- a/demo/main.lua
+++ b/demo/main.lua
@@ -649,9 +649,13 @@ function love.load()
 
     love.graphics.setBackgroundColor(200, 200, 200)
 
-    if not love.filesystem.isDirectory("sounds") then
+    local pathinfo = love.filesystem.getInfo("sounds")
+    if pathinfo == nil then
         love.filesystem.createDirectory("sounds")
+        pathinfo = love.filesystem.getInfo("sounds")
     end
+    assert(pathinfo.type == 'directory', '"sounds" exists in ' ..
+        love.filesystem.getRealDirectory('sounds') .. ' but is not a directory')
 
     sound = sfxr.newSound()
 

--- a/demo/main.lua
+++ b/demo/main.lua
@@ -2,6 +2,7 @@
 -- love .
 
 local sfxr = require("sfxr")
+local lf = require('loveframes/loveframes')
 
 -- Global stuff
 local source
@@ -515,7 +516,7 @@ function createOther()
             love.graphics.line(x, 25, x, 165)
         end
 
-        lf.skins.available["Orange"].DrawForm(o)
+        lf.GetActiveSkin().form(o)
     end
     f.Draw = draw
 
@@ -611,8 +612,8 @@ end
 
 function updateWaveCanvas(waveview)
     local t = love.timer.getTime()
-    wavecanvas:clear()
     love.graphics.setCanvas(wavecanvas)
+    love.graphics.clear(unpack(lf.GetActiveSkin().controls.frame_body_color))
     love.graphics.setColor(1, 1, 1)
     love.graphics.setLineStyle("rough")
 
@@ -644,9 +645,7 @@ function updateStatistics()
 end
 
 function love.load()
-    require("loveframes")
-    lf = loveframes
-    lf.util.SetActiveSkin("Orange")
+    lf.SetActiveSkin("Orange")
 
     love.graphics.setBackgroundColor(200, 200, 200)
 

--- a/demo/main.lua
+++ b/demo/main.lua
@@ -606,7 +606,7 @@ function updateParameters()
     s:SetValue(v)
     t:SetText("Repeat Speed " .. tostring(math.floor(v * 100) / 100))
 
-    guiparams.waveform:SetChoice(waveFormList[sound.wavetype])
+        guiparams.waveform:SetChoice(waveFormList[sound.waveform])
 end
 
 function updateWaveCanvas(waveview)

--- a/sfxr.lua
+++ b/sfxr.lua
@@ -1381,7 +1381,7 @@ function sfxr.Sound:load(f)
 
     local params, version = assert(loadstring(code))()
     -- check version compatibility
-    assert(version > sfxr.VERSION, "incompatible version: " .. tostring(version))
+    assert(version >= sfxr.VERSION, "incompatible version: loaded " .. tostring(version) .. " wanted >= " .. tostring(sfxr.VERSION))
 
     self:resetParameters()
     -- merge the loaded table into the own

--- a/sfxr.lua
+++ b/sfxr.lua
@@ -868,7 +868,7 @@ function sfxr.Sound:generateSoundData(rate, depth, sounddata)
         return nil
     end
 
-    local data = sounddata or love.sound.newSoundData(count, freq, bits, 1)
+    local data = sounddata or love.sound.newSoundData(count, rate, depth, 1)
 
     for i = 0, #tab - 1 do
         data:setSample(i, tab[i + 1])
@@ -1264,10 +1264,10 @@ function sfxr.Sound:exportWAV(f, rate, depth)
     w32(16) -- chunk size
     w16(1) -- compression code (1 = PCM)
     w16(1) -- channel number
-    w32(freq) -- sampling rate
-    w32(freq * bits / 8) -- bytes per second
-    w16(bits / 8) -- block alignment
-    w16(bits) -- bits per sample
+    w32(rate) -- sampling rate
+    w32(rate * depth / 8) -- bytes per second
+    w16(depth / 8) -- block alignment
+    w16(depth) -- bits per sample
 
     -- Write the header of the data chunk
     ws("data")
@@ -1292,9 +1292,9 @@ function sfxr.Sound:exportWAV(f, rate, depth)
 
     -- Seek back to the stored positions
     seek(pos_fsize)
-    w32(pos_csize - 4 + samples * bits / 8) -- remaining file size
+    w32(pos_csize - 4 + samples * depth / 8) -- remaining file size
     seek(pos_csize)
-    w32(samples * bits / 8) -- chunk size
+    w32(samples * depth / 8) -- chunk size
 
     if close then
         f:close()


### PR DESCRIPTION
This changeset contains two categories of fixes:

1. Update the demo GUI tool to work with LOVE 11.3
2. Address issues that were found when testing load/save after that.

For (1) the changes:
a. update to [the 11.x fork of LoveFrames](https://github.com/linux-man/LoveFrames) that is being maintained by @linux-man
b. change any color literals to use components in the range (0,1) instead of (0,255)
c. move usage of deprecated `love.filesystem` functions to current versions.
d. fix a field name that was probably incorrect for a long time but now causes an assertion failure in LoveFrames.
e. reflect changes to LoveFrames skin API

For (2) the changes:
a. Make the version check not fail if the expected version == the found version when loading a lua file.
b. Replace references to globals `freq` and `bits` that are not defined in `sfxr.lua` in the wav export code with locals `rate` and `depth`.