### PR TITLE
Default to a love-supported bit depth for SoundData

### DIFF
--- a/sfxr.lua
+++ b/sfxr.lua
@@ -858,7 +858,7 @@ end
 -- @raise "invalid sampling rate: x", "invalid bit depth: x"
 function sfxr.Sound:generateSoundData(rate, depth, sounddata)
     rate = rate or 44100
-    depth = depth or 0
+    depth = depth or 8 -- love supports 8 and 16
     assert(sfxr.SAMPLERATE[rate], "invalid sampling rate: " .. tostring(rate))
     assert(sfxr.BITDEPTH[depth] and depth, "invalid bit depth: " .. tostring(depth))
 


### PR DESCRIPTION
Fix "Invalid bit depth: 0" error in love when calling generateSoundData
without arguments.

[love.sound.newSoundData](https://love2d.org/wiki/love.sound.newSoundData)  in Love2d 11 (and earlier?) only supports 8 and 16, so don't default to 0
when generating a love object.